### PR TITLE
Use POSIX-style args on Windows too

### DIFF
--- a/optstyle_windows.go
+++ b/optstyle_windows.go
@@ -5,11 +5,12 @@ import (
 )
 
 // Windows uses a front slash for both short and long options.  Also it uses
-// a colon for name/argument delimter.
+// a colon for name/argument delimiter.
+// We've overridden them here though, for consistency between platforms.
 const (
-	defaultShortOptDelimiter = '/'
-	defaultLongOptDelimiter  = "/"
-	defaultNameArgDelimiter  = ':'
+	defaultShortOptDelimiter = '-'
+	defaultLongOptDelimiter  = "--"
+	defaultNameArgDelimiter  = '='
 )
 
 func argumentIsOption(arg string) bool {


### PR DESCRIPTION
Using POSIX-style command line args on Windows makes some of the CLI command manipulation that happens elsewhere more consistent between Windows and OS X/Linux.

This is mainly needed because of some of the [special handling around params in `flagutils`](https://github.com/sourcegraph/srclib/blob/master/flagutil/marshal.go#L27-L29). We could fix this directly in `flagutils`, but I reckon it's going to be better for consistency to just keep the params the same between OSes.

Note that the rest of the code in this file is still fine because it already dealt with POSIX-style args as an alternative.

Part of sourcegraph/srclib#149